### PR TITLE
add shape indices from momepy

### DIFF
--- a/ci/38-numba.yaml
+++ b/ci/38-numba.yaml
@@ -16,6 +16,7 @@ dependencies:
   - matplotlib
   # optional
   - geopandas
+  - pygeos>=0.10
   - sphinx>=1.4.3
   - sphinxcontrib-bibtex==1.0.0
   - sphinx_bootstrap_theme

--- a/ci/38.yaml
+++ b/ci/38.yaml
@@ -15,3 +15,4 @@ dependencies:
   - matplotlib
   # optional
   - geopandas>=0.7.0
+  - pygeos>=0.10

--- a/docs/_static/references.bib
+++ b/docs/_static/references.bib
@@ -1,10 +1,10 @@
 %% This BibTeX bibliography file was created using BibDesk.
 %% https://bibdesk.sourceforge.io/
 
-%% Created for weikang at 2019-03-28 22:46:35 -0700 
+%% Created for weikang at 2019-03-28 22:46:35 -0700
 
 
-%% Saved with string encoding Unicode (UTF-8) 
+%% Saved with string encoding Unicode (UTF-8)
 
 @Article{Lee2001,
 author="Lee, Sang-Il",
@@ -169,7 +169,7 @@ url="https://doi.org/10.1007/s101090100064"
   year = {1987},
   pages = {53--65}
 }
-  
+
 @Article{lunnwinbugs,
 author="Lunn, David J.
 and Thomas, Andrew
@@ -205,4 +205,63 @@ url="https://doi.org/10.1023/A:1008929526011"
 	year={1998},
 	volume=30,
 	issue=4
+}
+
+
+@article{basaraner2017,
+  title = {Performance of Shape Indices and Classification Schemes for Characterising Perceptual Shape Complexity of Building Footprints in {{GIS}}},
+  author = {Basaraner, Melih and Cetinkaya, Sinan},
+  year = {2017},
+  month = jul,
+  volume = {31},
+  pages = {1952--1977},
+  doi = {10.1080/13658816.2017.1346257},
+  journal = {International Journal of Geographical Information Science},
+  number = {10}
+}
+
+@article{maceachren1985compactness,
+  title={Compactness of geographic shape: Comparison and evaluation of measures},
+  author={MacEachren, Alan M},
+  journal={Geografiska Annaler: Series B, Human Geography},
+  volume={67},
+  number={1},
+  pages={53--67},
+  year={1985},
+  publisher={Taylor \& Francis}
+}
+
+@article{gil2012,
+  title = {On the {{Discovery}} of {{Urban Typologies}}: {{Data Mining}} the {{Multi}}-Dimensional {{Character}} of {{Neighbourhoods}}},
+  author = {Gil, Jorge and Montenegro, Nuno and Beir{\~a}o, J N and Duarte, J P},
+  year = {2012},
+  month = jan,
+  volume = {16},
+  pages = {27--40},
+  journal = {Urban Morphology},
+  number = {1}
+}
+
+@article{bourdic2012,
+  title = {Assessing Cities: A New System of Cross-Scale Spatial Indicators},
+  author = {Bourdic, Loeiz and Salat, Serge and Nowacki, Caroline},
+  year = {2012},
+  month = jan,
+  volume = {40},
+  pages = {592--605},
+  doi = {10.1080/09613218.2012.703488},
+  journal = {Building Research \& Information},
+  number = {5}
+}
+
+@article{schirmer2015,
+  title = {A Multiscale Classification of Urban Morphology},
+  author = {Schirmer, Patrick Michael and Axhausen, Kay W},
+  year = {2015},
+  month = may,
+  volume = {9},
+  pages = {101--130},
+  doi = {10.5198/jtlu.2015.667},
+  journal = {Journal of Transport and Land Use},
+  number = {1}
 }

--- a/esda/shape.py
+++ b/esda/shape.py
@@ -250,6 +250,126 @@ def fractal_dimension(collection, support="hex"):
         )
 
 
+def squareness(collection):
+    """measures how different is a given shape from an equi-areal square
+
+    The index is close to 0 for highly irregular shapes and to 1.3 for circular shapes.
+    It equals 1 for squares.
+
+    .. math::
+        \frac{\sqrt{A}}{P^{2}} \times \frac{\left(4 \sqrt{\left.A\right)}^{2}\right.}{\sqrt{A}}=\frac{\left(4 \sqrt{A}\right)^{2}}{P^{2}}=\left(\frac{4 \sqrt{A}}{P}}\right)^{2}
+
+    :cite:`basaraner2017`
+
+    """
+    ga = _cast(collection)
+    return ((numpy.sqrt(pygeos.area(ga)) * 4) / pygeos.length(ga)) ** 2
+
+
+def rectangularity(collection):
+    """ratio of the area of the shape to the area of its minimum rotated rectangle
+
+    reveals a polygon’s degree of being curved inward
+
+    :cite:`basaraner2017`
+    """
+    ga = _cast(collection)
+    return pygeos.area(ga) / pygeos.area(pygeos.minimum_rotated_rectangle(ga))
+
+
+def shape_index(collection):
+    """
+    Schumm’s shape index (Schumm (1956) in MacEachren 1985)
+    """
+    ga = _cast(collection)
+    return numpy.sqrt(pygeos.area(ga) / numpy.pi) / pygeos.minimum_bounding_radius(ga)
+
+
+def equivalent_rectangular_index(collection):
+    """deviation of a polygon from an equivalent rectangle
+
+    .. math::
+        \\sqrt{{area} \\over \\textit{area of bounding rectangle}} *
+        {\\textit{perimeter of bounding rectangle} \\over {perimeter}}
+
+    Based on :cite:`basaraner2017`.
+    """
+    ga = _cast(collection)
+    box = pygeos.minimum_rotated_rectangle(ga)
+    return numpy.sqrt(pygeos.area(ga) / pygeos.area(box)) * (
+        pygeos.length(box) / pygeos.length(ga)
+    )
+
+
+def elongation(collection):
+    """
+    Calculates elongation of object seen as elongation of
+    its minimum bounding rectangle.
+
+    .. math::
+        {{p - \\sqrt{p^2 - 16a}} \\over {4}} \\over
+        {{{p} \\over {2}} - {{p - \\sqrt{p^2 - 16a}} \\over {4}}}
+
+    where `a` is the area of the object and `p` its perimeter.
+
+    Based on :cite:`gil2012`.
+    """
+    ga = _cast(collection)
+    box = pygeos.minimum_rotated_rectangle(ga)
+    A = pygeos.area(box)
+    P = pygeos.length(box)
+    cond1 = P ** 2
+    cond2 = 16 * A
+    bigger = cond1 >= cond2
+    sqrt = numpy.zeros(len(A))
+    sqrt[bigger] = cond1[bigger] - cond2[bigger]
+
+    # calculate both width/length and length/width
+    elo1 = ((P - numpy.sqrt(sqrt)) / 4) / ((P / 2) - ((P - numpy.sqrt(sqrt)) / 4))
+    elo2 = ((P + numpy.sqrt(sqrt)) / 4) / ((P / 2) - ((P + numpy.sqrt(sqrt)) / 4))
+
+    # use the smaller one (e.g. shorter/longer)
+    res = numpy.empty(len(a))
+    res[elo1 <= elo2] = elo1[elo1 <= elo2]
+    res[~(elo1 <= elo2)] = elo2[~(elo1 <= elo2)]
+
+    return res
+
+
+# -------------------- VOLMETRIC MEASURES ------------------- #
+
+
+def form_factor(collection, height):
+    """computes volumetric compactness
+
+    .. math::
+        area \\over {volume^{2 \\over 3}}
+
+    Adapted from :cite:`bourdic2012`.
+    """
+    ga = _cast(collection)
+    A = pygeos.area(ga)
+    V = A * height
+    zeros = V == 0
+    res = numpy.zeros(len(ga))
+    res[~zeros] = A[~zeros] / (V[~zeros] ** (2 / 3))
+    return res
+
+
+def volume_wall_ratio(collection, height):
+    """volumetric compacntess
+
+    In morphological literature often as volume/facade ratio.
+
+    .. math::
+        volume \\over perimeter * height
+
+    Adapted from :cite:`schirmer2015`.
+    """
+    ga = _cast(collection)
+    return (pygeos.area(ga) * height) / (pygeos.length(ga) * height)
+
+
 # -------------------- INERTIAL MEASURES -------------------- #
 
 

--- a/esda/tests/test_shape.py
+++ b/esda/tests/test_shape.py
@@ -92,3 +92,33 @@ def test_fractal_dimension():
     ]
 
     testing.assert_allclose(r, [0.218144, -4.29504, 0.257882], atol=ATOL)
+
+
+def test_squareness():
+    observed = squareness(shape)
+    testing.assert_allclose(observed, 0.493094, atol=ATOL)
+
+
+def test_rectangularity():
+    observed = rectangularity(shape)
+    testing.assert_allclose(observed, 0.7, atol=ATOL)
+
+
+def test_shape_index():
+    observed = shape_index(shape)
+    testing.assert_allclose(observed, 0.659366, atol=ATOL)
+
+
+def test_equivalent_rectangular_index():
+    observed = equivalent_rectangular_index(shape)
+    testing.assert_allclose(observed, 0.706581, atol=ATOL)
+
+
+def test_form_factor():
+    observed = form_factor(shape, array([2]))
+    testing.assert_allclose(observed, 0.602535, atol=ATOL)
+
+
+def test_volume_wall_ratio():
+    observed = volume_wall_ratio(shape, array([2]))
+    testing.assert_allclose(observed, 0.164213, atol=ATOL)

--- a/esda/tests/test_shape.py
+++ b/esda/tests/test_shape.py
@@ -1,10 +1,12 @@
 from shapely import geometry
-from esda.shape import *
 from numpy import testing, array
 import pytest
 
 pygeos = pytest.importorskip("pygeos")
 pytest.importorskip("numba")
+
+from esda.shape import *
+
 
 shape = array(
     [

--- a/esda/tests/test_shape.py
+++ b/esda/tests/test_shape.py
@@ -4,6 +4,7 @@ from numpy import testing, array
 import pytest
 
 pygeos = pytest.importorskip("pygeos")
+pytest.importorskip("numba")
 
 shape = array(
     [

--- a/esda/tests/test_shape.py
+++ b/esda/tests/test_shape.py
@@ -1,11 +1,13 @@
 from shapely import geometry
-from pygeos import from_shapely
 from esda.shape import *
 from numpy import testing, array
+import pytest
+
+pygeos = pytest.importorskip("pygeos")
 
 shape = array(
     [
-        from_shapely(
+        pygeos.from_shapely(
             geometry.Polygon(
                 [
                     (0, 0),


### PR DESCRIPTION
This brings the bulk of chape characters which are not already included from `momepy.shape`. 

I also wanted to port `squareness` (for which we need to find a better name), which measure the mean deviation of corner angle from 90º but I first need to figure out/fix `get_angles` (see the comment in your PR).

There's a few more that are not moved yet as I am not sure we want them here:
- Courtyard index - an area of holes vs area of a polygon
- Corners - number of corners (includes a threshold to exclude vertices which are not considered a corner)
- Linearity - works only for linestrings as a ratio of start-end euclidean distance to the length of the geometry